### PR TITLE
Fixed missing buffer initialization

### DIFF
--- a/lib/bufferwriter.js
+++ b/lib/bufferwriter.js
@@ -5,6 +5,7 @@ var Qap = require('qap');
 var BufferConsumer = require('./bufferconsumer');
 var BufferWriter = module.exports = function (size) {
   this.buf = new Buffer(size || 512);
+  this.buf.fill(0);
   this.offset = 0;
 };
 


### PR DESCRIPTION
I sometimes notice that my program freezes when calling `DNSPacket.toBuffer()`.
The program is looping in the function `BufferWriter.prototype.name` here https://github.com/kmpm/node-mdns-js-packet/blob/master/lib/bufferwriter.js#L93 : the non initialized buffer may already contain the searched pattern, resulting in a forever loop.
Initializing the buffer to 0 fixes the issue.