### PR TITLE
Fixed invalid parsed value of TTL in DNSRecord when 0

### DIFF
--- a/lib/dnsrecord.js
+++ b/lib/dnsrecord.js
@@ -27,7 +27,7 @@ var DNSRecord = module.exports = function (name, type, cl, optTTL) {
     throw new errors.MalformedPacket('Record.class is empty');
   }
 
-  this.ttl = optTTL || DNSRecord.TTL;
+  this.ttl = (typeof(optTTL) !== 'undefined') ? optTTL : DNSRecord.TTL;
   this.isQD = (arguments.length === 3);
   debug('new DNSRecord', this);
 
@@ -71,10 +71,10 @@ DNSRecord.Type = {
 * @enum {number}
 */
 DNSRecord.Class = {
-IN: 0x01,
-ANY: 0xff,
-FLUSH: 0x8000,
-IS_QM: 0x8000
+  IN: 0x01,
+  ANY: 0xff,
+  FLUSH: 0x8000,
+  IS_QM: 0x8000
 };
 
 

--- a/test/record-parse.test.js
+++ b/test/record-parse.test.js
@@ -49,4 +49,26 @@ describe('DNSRecord (Parse)', function () {
       done();
     });
   });//OPT
+  
+  
+  describe('A - TTL', function () {
+    it('parse A TTL=0', function (done) {
+      var buf = new Buffer('00000180010000000000040a500a22',
+        'hex');
+      var r = DNSRecord.parse(buf);
+      expect(r.type).to.equal(DNSRecord.Type.A);
+      expect(r.ttl).to.equal(0);
+      done();
+    });
+
+    it('parse A TTL=20', function (done) {
+      var buf = new Buffer('00000180010000001400040a500a22',
+        'hex');
+      var r = DNSRecord.parse(buf);
+      expect(r.type).to.equal(DNSRecord.Type.A);
+      expect(r.ttl).to.equal(20);
+      done();
+    });
+
+  });//A-TTL
 });

--- a/test/record-parse.test.js
+++ b/test/record-parse.test.js
@@ -49,8 +49,8 @@ describe('DNSRecord (Parse)', function () {
       done();
     });
   });//OPT
-  
-  
+
+
   describe('A - TTL', function () {
     it('parse A TTL=0', function (done) {
       var buf = new Buffer('00000180010000000000040a500a22',
@@ -69,6 +69,5 @@ describe('DNSRecord (Parse)', function () {
       expect(r.ttl).to.equal(20);
       done();
     });
-
   });//A-TTL
 });


### PR DESCRIPTION
When parsing a buffer with a TTL value of 0, the generated DNS record has a TTL with the default value instead of 0;
The problem comes from the *short circuit evaluation* here https://github.com/kmpm/node-mdns-js-packet/blob/master/lib/dnsrecord.js#L30 : 
`  this.ttl = optTTL || DNSRecord.TTL;`
Since optTTL is a number it is also considered as `false` when equal to 0, setting the TTL to the default value. 
