### PR TITLE
[TXT] android resolver doesn't like the encoding

### DIFF
--- a/lib/dnsrecord.js
+++ b/lib/dnsrecord.js
@@ -132,7 +132,9 @@ DNSRecord.write = function (out, rec, withLength) {
     case DNSRecord.Type.TXT:
       for (var key in rec.data) {
         if (rec.data.hasOwnProperty(key)) {
-          out.name(key + '=' + rec.data[key], true);
+          // properly encode this
+          out.name(key + '=' + rec.data[key]);
+          out.offset--;
         }
       }
       break;


### PR DESCRIPTION
the android resolver would “punt” not liking the length value in the TXT RR. the modification works for android, iOS, linux, and mac os x clients, so i’m assuming that the latter 3 are more “liberal in what they accept”. this PR makes the generator more conservative in what it sends, cf., https://en.wikipedia.org/wiki/Robustness_principle