### PR TITLE
Use buffer rather than string to support mb chars

### DIFF
--- a/lib/bufferwriter.js
+++ b/lib/bufferwriter.js
@@ -92,8 +92,8 @@ BufferWriter.prototype.name = function (v) {
   var lastPart = parts.length;
   if (v.length > 0) {
     for (i = 0; i < parts.length; i++) {
-      part = parts[i];
-      qap.set(String.fromCharCode(part.length) + part);
+      part = new Buffer(parts[i]);
+      qap.set(Buffer.concat([ new Buffer([ part.length ]), part ]));
       var location = qap.parse(self.buf)[0];
       if (location) {
         var tr = consumer.seek(location).name();
@@ -110,11 +110,11 @@ BufferWriter.prototype.name = function (v) {
   var out = new BufferWriter();
   debug('lastPart', lastPart);
   for (i = 0; i < lastPart; i++) {
-    part = parts[i];
+    part = new Buffer(parts[i]);
     debug('writing part', part);
     out.byte(part.length);
     for (j = 0; j < part.length; ++j) {
-      out.byte(part.charCodeAt(j));
+      out.byte(part[j]);
     }
   }
 


### PR DESCRIPTION
Using buffers instead of strings when building an output buffer allows multibyte characters to be used in the name field. This is necessary for `node-mdns-js` to stop being crashed for names written in non-latin characters.
